### PR TITLE
03_scope :qに関するエラー解消

### DIFF
--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -1,3 +1,23 @@
 // Place all the styles related to the books controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.container{
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+
+  /*並び順*/
+  /*
+  flex-start：左寄せ（デフォルト）
+  flex-end：右寄せ
+  center： 中央寄せ
+  space-between：残り余白の均等割り
+  space-around：左右余白 ＋ 均等割り
+  */
+  justify-content: center;
+}
+.flex-item{
+  width: 100px;
+  height: 100px;
+}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,7 +2,7 @@ class BooksController < ApplicationController
   def search
     @search_form = SearchBooksForm.new(search_books_params)
     books = GoogleBook.search(@search_form.keyword)
-    @books = Kaminari.paginate_array(books).page(params[:page])
+    @books = Kaminari.paginate_array(books).page(params[:page]).per(10)
   end
 
   def create
@@ -17,7 +17,8 @@ class BooksController < ApplicationController
   private
 
   def search_books_params
-    params.fetch(:search_books_form).permit(:keyword)
+    # params.fetch(:search_books_form).permit(:keyword)
+    params.fetch(:q, keyword: '').permit(:keyword)
   end
 
   def create_book_params

--- a/app/views/books/search.html.slim
+++ b/app/views/books/search.html.slim
@@ -1,10 +1,14 @@
-= form_with model: @search_form, url: search_books_path, local: true, method: :get do |f|
+= form_with model: @search_form, url: search_books_path, local: true, scope: :q,  method: :get do |f|
   .form-group
     = f.label :keyword, 'キーワード'
     = f.text_field :keyword, class: 'form-control', value: @search_form.keyword
   = f.submit '検索する'
 
-= @books.each do |book|
-  = image_tag book.image
-  = book.title
-  = book.authors
+.container
+  .flex-item
+    - if @books
+      = @books.each do |book|
+        - if book.image
+          = image_tag book.image
+        = book.title
+        = book.authors


### PR DESCRIPTION
##
``` slim
= form_with model: @search_form, url: search_books_path, local: true, scope: q, method: :get do |f|
  .form-group
    = f.label :keyword, 'キーワード'
    = f.text_field :keyword, class: 'form-control', value: @search_form.keyword
  = f.submit '検索する'
```

```
= form_with model: @search_form, url: search_books_path, local: true, scope: :q, method: :get do |f|

```
が正。

## 参考
 - [【Ruby on Rails】フォームオブジェクトを使って検索キーワードをcontrollerに送る - Qiita](https://qiita.com/kumackey/items/4f8f0cd39d02299d74ed)

